### PR TITLE
Improve dev startup CLI resolution for Codex binaries

### DIFF
--- a/scripts/start-dev.js
+++ b/scripts/start-dev.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 /**
  * Smart development startup script
- * Automatically detects system architecture and sets correct CLI path
+ * Automatically detects system architecture and sets correct CLI path.
+ *
+ * Resolution order:
+ *   1) resources/bin/<platform-arch>/codex(.exe)
+ *   2) node_modules/@cometix/codex/vendor/<target-triple>/codex/codex(.exe)
  */
 
 const { spawn } = require('child_process');
@@ -9,58 +13,84 @@ const path = require('path');
 const os = require('os');
 const fs = require('fs');
 
-// Detect platform and architecture
+const TARGET_TRIPLE_MAP = {
+  'darwin-x64': 'x86_64-apple-darwin',
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'linux-x64': 'x86_64-unknown-linux-musl',
+  'linux-arm64': 'aarch64-unknown-linux-musl',
+  'win32-x64': 'x86_64-pc-windows-msvc',
+};
+
+function resolveCodexCli(platform, arch) {
+  const platformArch = `${platform}-${arch}`;
+  const cliName = platform === 'win32' ? 'codex.exe' : 'codex';
+
+  const attempts = [];
+
+  const localPath = path.join(__dirname, '..', 'resources', 'bin', platformArch, cliName);
+  attempts.push(localPath);
+  if (fs.existsSync(localPath)) {
+    return { cliPath: localPath, source: 'resources/bin', attempts };
+  }
+
+  const targetTriple = TARGET_TRIPLE_MAP[platformArch];
+  if (targetTriple) {
+    const npmPath = path.join(
+      __dirname,
+      '..',
+      'node_modules',
+      '@cometix',
+      'codex',
+      'vendor',
+      targetTriple,
+      'codex',
+      cliName,
+    );
+    attempts.push(npmPath);
+    if (fs.existsSync(npmPath)) {
+      return { cliPath: npmPath, source: 'node_modules/@cometix/codex', attempts };
+    }
+  }
+
+  return { cliPath: null, source: null, attempts };
+}
+
 const platform = process.platform;
 const arch = os.arch();
 
-// Map to CLI binary paths
-const platformMap = {
-  darwin: {
-    x64: 'darwin-x64',
-    arm64: 'darwin-arm64',
-  },
-  linux: {
-    x64: 'linux-x64',
-    arm64: 'linux-arm64',
-  },
-  win32: {
-    x64: 'win32-x64',
-  },
-};
-
-const binDir = platformMap[platform]?.[arch];
-if (!binDir) {
+if (!TARGET_TRIPLE_MAP[`${platform}-${arch}`]) {
   console.error(`Unsupported platform/arch: ${platform}/${arch}`);
   process.exit(1);
 }
 
-const cliName = platform === 'win32' ? 'codex.exe' : 'codex';
-const cliPath = path.join(__dirname, '..', 'resources', 'bin', binDir, cliName);
-
-// Verify CLI exists
-if (!fs.existsSync(cliPath)) {
-  console.error(`CLI not found at: ${cliPath}`);
-  console.error('Please ensure the CLI binary exists in resources/bin/');
+const resolved = resolveCodexCli(platform, arch);
+if (!resolved.cliPath) {
+  console.error(`CLI not found for ${platform}/${arch}`);
+  console.error('Checked paths:');
+  for (const attempted of resolved.attempts) {
+    console.error(`  - ${attempted}`);
+  }
+  console.error('Run `npm install` (to fetch @cometix/codex) or add binaries under resources/bin/.');
   process.exit(1);
 }
 
 console.log(`[start-dev] Platform: ${platform}, Arch: ${arch}`);
-console.log(`[start-dev] CLI Path: ${cliPath}`);
+console.log(`[start-dev] CLI Source: ${resolved.source}`);
+console.log(`[start-dev] CLI Path: ${resolved.cliPath}`);
 
-// Launch Electron with CLI path
 const electronBin = require('electron');
 const child = spawn(electronBin, ['.'], {
   cwd: path.join(__dirname, '..'),
   stdio: 'inherit',
   env: {
     ...process.env,
-    CODEX_CLI_PATH: cliPath,
+    CODEX_CLI_PATH: resolved.cliPath,
     BUILD_FLAVOR: process.env.BUILD_FLAVOR || 'dev',
-    // 使用 app:// 自定义协议加载静态资源（而非 Vite dev server）
+    // Use app:// protocol to load bundled renderer assets (not Vite dev server)
     ELECTRON_RENDERER_URL: process.env.ELECTRON_RENDERER_URL || 'app://-/index.html',
   },
 });
 
 child.on('close', (code) => {
-  process.exit(code);
+  process.exit(code ?? 0);
 });


### PR DESCRIPTION
## What this updates
- Updates `scripts/start-dev.js` to resolve the Codex CLI from multiple sources:
  1. `resources/bin/<platform-arch>/codex(.exe)`
  2. `node_modules/@cometix/codex/vendor/<target-triple>/codex/codex(.exe)`

## Why
- `npm run dev` previously failed when `resources/bin` was not populated.
- With this change, a clean `npm install` can still run dev mode by using the bundled `@cometix/codex` binary fallback.

## Behavior changes
- Logs now show CLI source (`resources/bin` vs `node_modules/@cometix/codex`).
- Error output now lists all attempted CLI paths for easier debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal CLI resolution logic and error diagnostics for better troubleshooting during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->